### PR TITLE
Add bundle configuration and UI rendering

### DIFF
--- a/config/app-config.js
+++ b/config/app-config.js
@@ -38,11 +38,14 @@
             location: 'Helsinki, FI',
             deliverySpeed: '15-30 мин'
         },
+        bundles: [
+            { items: ['chipsy_krevetka', 'lemonad'], price: 350 }
+        ],
         recommendationItems_home: [
-            'raspberry_artfruit', 
-            'vinograd', 
-            'golubika', 
-            'makadamia', 
+            'raspberry_artfruit',
+            'vinograd',
+            'golubika',
+            'makadamia',
             'goroh', 
             'savushkin', 
             'cvety',

--- a/index.html
+++ b/index.html
@@ -144,6 +144,7 @@
     </div>
 
     <div class="visual-container">
+        <div class="bundles recommendations-grid"></div>
         <!-- Recommendations -->
         <div class="recommendations">
             <!-- Promo Banner -->


### PR DESCRIPTION
## Summary
- add bundle configuration for chips and lemonade combo
- display bundle cards with one-click add-to-cart
- initialize bundle rendering across cart tabs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b005cb03dc832590792c9d10609e1a